### PR TITLE
refactor bot - separate concerns and separate slack api

### DIFF
--- a/lib/pii_detector/platform/slack/api.ex
+++ b/lib/pii_detector/platform/slack/api.ex
@@ -1,0 +1,131 @@
+defmodule PIIDetector.Platform.Slack.API do
+  @moduledoc """
+  Implementation of Slack API interactions.
+  """
+
+  @behaviour PIIDetector.Platform.Slack.APIBehaviour
+  require Logger
+  alias PIIDetector.Platform.Slack.MessageFormatter
+
+  # Default underlying API module
+  @slack_api Slack.API
+
+  # Get the actual Slack API module (allows for test mocking)
+  defp slack_api do
+    Application.get_env(:pii_detector, :slack_underlying_api, @slack_api)
+  end
+
+  # Get admin token from environment
+  defp admin_token do
+    System.get_env("SLACK_ADMIN_TOKEN")
+  end
+
+  @impl PIIDetector.Platform.Slack.APIBehaviour
+  def post(endpoint, token, params) do
+    slack_api().post(endpoint, token, params)
+  end
+
+  @doc """
+  Deletes a message from a channel.
+  Tries to use admin token first, falls back to bot token if admin token is not available.
+
+  ## Parameters
+  - channel: The channel ID
+  - ts: The timestamp of the message
+  - bot_token: The bot token to use as fallback
+
+  ## Returns
+  - {:ok, :deleted} on success
+  - {:error, reason} on failure
+  """
+  @impl PIIDetector.Platform.Slack.APIBehaviour
+  def delete_message(channel, ts, bot_token) do
+    # Try with admin token first
+    case delete_message_with_admin(channel, ts) do
+      {:error, :admin_token_not_set} ->
+        # Fall back to bot token if admin token is not set
+        delete_message_with_token(channel, ts, bot_token)
+
+      result ->
+        result
+    end
+  end
+
+  @doc """
+  Sends a notification to a user about a deleted message.
+
+  ## Parameters
+  - user_id: The user ID to notify
+  - message_content: The content of the deleted message
+  - bot_token: The bot token to use for the API call
+
+  ## Returns
+  - {:ok, :notified} on success
+  - {:error, reason} on failure
+  """
+  @impl PIIDetector.Platform.Slack.APIBehaviour
+  def notify_user(user_id, message_content, bot_token) do
+    Logger.debug("Opening conversation with user #{user_id}")
+
+    with {:ok, %{"ok" => true, "channel" => %{"id" => channel_id}}} <-
+           post("conversations.open", bot_token, %{users: user_id}),
+         notification = MessageFormatter.format_pii_notification(message_content),
+         {:ok, %{"ok" => true}} <-
+           post("chat.postMessage", bot_token, %{
+             channel: channel_id,
+             text: notification
+           }) do
+      Logger.info("Successfully sent notification to user #{user_id}")
+      {:ok, :notified}
+    else
+      {:ok, %{"ok" => false, "error" => error}} ->
+        Logger.error("Failed to notify user #{user_id}: #{error}")
+        {:error, error}
+
+      {:error, error} ->
+        Logger.error("Server error when notifying user #{user_id}: #{inspect(error)}")
+        {:error, :server_error}
+    end
+  end
+
+  # Private helper functions
+
+  # Delete a message using admin token
+  defp delete_message_with_admin(channel, ts) do
+    admin_token = admin_token()
+
+    if admin_token == nil || admin_token == "" do
+      Logger.warning("Admin token not set, falling back to bot token for message deletion")
+      {:error, :admin_token_not_set}
+    else
+      delete_message_with_token(channel, ts, admin_token)
+    end
+  end
+
+  # Delete a message using specified token
+  defp delete_message_with_token(channel, ts, token) do
+    Logger.debug("Attempting to delete message in #{channel} with ts #{ts}")
+
+    case post("chat.delete", token, %{channel: channel, ts: ts}) do
+      {:ok, %{"ok" => true}} ->
+        Logger.info("Successfully deleted message in #{channel}")
+        {:ok, :deleted}
+
+      {:ok, %{"ok" => false, "error" => "cant_delete_message"}} ->
+        Logger.warning("Cannot delete message in #{channel}: permission denied")
+        {:error, :cant_delete_message}
+
+      {:ok, %{"ok" => false, "error" => "message_not_found"}} ->
+        Logger.warning("Cannot delete message in #{channel}: message not found")
+        {:error, :message_not_found}
+
+      {:ok, %{"ok" => false, "error" => error}} ->
+        Logger.error("Failed to delete message in #{channel}: #{error}")
+        {:error, error}
+
+      {:error, error} ->
+        Logger.error("Server error when deleting message in #{channel}: #{inspect(error)}")
+        {:error, :server_error}
+    end
+  end
+end

--- a/lib/pii_detector/platform/slack/api_behaviour.ex
+++ b/lib/pii_detector/platform/slack/api_behaviour.ex
@@ -1,4 +1,4 @@
-defmodule PIIDetector.Slack.APIBehaviour do
+defmodule PIIDetector.Platform.Slack.APIBehaviour do
   @moduledoc """
   Behaviour module for Slack API interactions.
   This allows us to mock the Slack API calls in tests.
@@ -17,4 +17,32 @@ defmodule PIIDetector.Slack.APIBehaviour do
   - {:error, reason} on failure
   """
   @callback post(String.t(), String.t(), map()) :: {:ok, map()} | {:error, any()}
+
+  @doc """
+  Deletes a message from a channel.
+
+  ## Parameters
+  - channel: The channel ID
+  - ts: The timestamp of the message
+  - bot_token: The bot token to use as fallback
+
+  ## Returns
+  - {:ok, :deleted} on success
+  - {:error, reason} on failure
+  """
+  @callback delete_message(String.t(), String.t(), String.t()) :: {:ok, :deleted} | {:error, any()}
+
+  @doc """
+  Sends a notification to a user about a deleted message.
+
+  ## Parameters
+  - user_id: The user ID to notify
+  - message_content: The content of the deleted message
+  - bot_token: The bot token to use for the API call
+
+  ## Returns
+  - {:ok, :notified} on success
+  - {:error, reason} on failure
+  """
+  @callback notify_user(String.t(), map(), String.t()) :: {:ok, :notified} | {:error, any()}
 end

--- a/lib/pii_detector/platform/slack/api_behaviour.ex
+++ b/lib/pii_detector/platform/slack/api_behaviour.ex
@@ -30,7 +30,8 @@ defmodule PIIDetector.Platform.Slack.APIBehaviour do
   - {:ok, :deleted} on success
   - {:error, reason} on failure
   """
-  @callback delete_message(String.t(), String.t(), String.t()) :: {:ok, :deleted} | {:error, any()}
+  @callback delete_message(String.t(), String.t(), String.t()) ::
+              {:ok, :deleted} | {:error, any()}
 
   @doc """
   Sends a notification to a user about a deleted message.

--- a/lib/pii_detector/platform/slack/bot.ex
+++ b/lib/pii_detector/platform/slack/bot.ex
@@ -4,26 +4,14 @@ defmodule PIIDetector.Platform.Slack.Bot do
   """
   use Slack.Bot
   require Logger
+  alias PIIDetector.Platform.Slack.API
 
   # Use PIIDetector by default, but allow for mocking in tests
   @detector PIIDetector.Detector.PIIDetector
 
-  # Default API module
-  @api_module Slack.API
-
   # Get the actual detector module (allows for test mocking)
   defp detector do
     Application.get_env(:pii_detector, :pii_detector_module, @detector)
-  end
-
-  # Get the API module (allows for test mocking)
-  defp api do
-    Application.get_env(:pii_detector, :slack_api_module, @api_module)
-  end
-
-  # Add function to get the admin token directly from environment
-  defp admin_token do
-    System.get_env("SLACK_ADMIN_TOKEN")
   end
 
   @impl true
@@ -47,25 +35,19 @@ defmodule PIIDetector.Platform.Slack.Bot do
     # Extract message data for PII detection
     message_content = extract_message_content(message)
 
-    # In Task 4, replace this with actual PII detection
-    # For now, just log that we received a message
+    # Log the received message
     Logger.debug("Received message from #{user} in #{channel}")
 
-    # Example of detecting PII with our placeholder detector
+    # Detect PII in the message
     case detector().detect_pii(message_content) do
       {:pii_detected, true, categories} ->
         Logger.info("Detected PII in categories: #{inspect(categories)}")
-        # Try with admin token first, fall back to bot token if admin token isn't set
-        case delete_message_with_admin(channel, ts) do
-          {:error, :admin_token_not_set} ->
-            # Fall back to bot token if admin token is not set
-            delete_message_with_bot(channel, ts, bot.token)
 
-          result ->
-            result
-        end
+        # Delete the message
+        API.delete_message(channel, ts, bot.token)
 
-        notify_user(user, message_content, bot.token)
+        # Notify the user
+        API.notify_user(user, message_content, bot.token)
 
       {:pii_detected, false, _} ->
         # No PII detected, do nothing
@@ -90,95 +72,5 @@ defmodule PIIDetector.Platform.Slack.Bot do
       files: message["files"] || [],
       attachments: message["attachments"] || []
     }
-  end
-
-  # Delete a message using admin token
-  defp delete_message_with_admin(channel, ts) do
-    # Try to get admin token from different sources
-    # 1. Try from Application.get_env
-    # 2. Try from Process dictionary (set during init)
-    # 3. Use a fallback if neither is available
-    admin_token = admin_token()
-
-    if admin_token == nil || admin_token == "" do
-      Logger.warning("Admin token not set, falling back to bot token for message deletion")
-      {:error, :admin_token_not_set}
-    else
-      delete_message(channel, ts, admin_token)
-    end
-  end
-
-  # Delete a message using bot token
-  defp delete_message_with_bot(channel, ts, bot_token) do
-    delete_message(channel, ts, bot_token)
-  end
-
-  # Delete a message using specified token
-  defp delete_message(channel, ts, token) do
-    Logger.debug("Attempting to delete message in #{channel} with ts #{ts}")
-
-    case api().post("chat.delete", token, %{channel: channel, ts: ts}) do
-      {:ok, %{"ok" => true}} ->
-        Logger.info("Successfully deleted message in #{channel}")
-        {:ok, :deleted}
-
-      {:ok, %{"ok" => false, "error" => "cant_delete_message"}} ->
-        Logger.warning("Cannot delete message in #{channel}: permission denied")
-        {:error, :cant_delete_message}
-
-      {:ok, %{"ok" => false, "error" => "message_not_found"}} ->
-        Logger.warning("Cannot delete message in #{channel}: message not found")
-        {:error, :message_not_found}
-
-      {:ok, %{"ok" => false, "error" => error}} ->
-        Logger.error("Failed to delete message in #{channel}: #{error}")
-        {:error, error}
-
-      {:error, error} ->
-        Logger.error("Server error when deleting message in #{channel}: #{inspect(error)}")
-        {:error, :server_error}
-    end
-  end
-
-  # Notify user about deleted message
-  defp notify_user(user_id, message_content, bot_token) do
-    Logger.debug("Opening conversation with user #{user_id}")
-
-    with {:ok, %{"ok" => true, "channel" => %{"id" => channel_id}}} <-
-           api().post("conversations.open", bot_token, %{users: user_id}),
-         notification = build_notification_message(message_content),
-         {:ok, %{"ok" => true}} <-
-           api().post("chat.postMessage", bot_token, %{
-             channel: channel_id,
-             text: notification
-           }) do
-      Logger.info("Successfully sent notification to user #{user_id}")
-      {:ok, :notified}
-    else
-      {:ok, %{"ok" => false, "error" => error}} ->
-        Logger.error("Failed to notify user #{user_id}: #{error}")
-        {:error, error}
-
-      {:error, error} ->
-        Logger.error("Server error when notifying user #{user_id}: #{inspect(error)}")
-        {:error, :server_error}
-    end
-  end
-
-  # Build notification message
-  defp build_notification_message(message_content) do
-    """
-    :warning: Your message has been removed because it contained personal identifiable information (PII).
-    Please post messages without sensitive information such as:
-    • Social security numbers
-    • Credit card numbers
-    • Personal addresses
-    • Full names with contact information
-    • Email addresses
-    Here's your original message for reference:
-    ```
-    #{message_content.text}
-    ```
-    """
   end
 end

--- a/test/pii_detector/platform/slack/bot_test.exs
+++ b/test/pii_detector/platform/slack/bot_test.exs
@@ -185,7 +185,10 @@ defmodule PIIDetector.Platform.Slack.BotTest do
       "chat.postMessage", token, params ->
         assert token == "xoxb-test-token"
         assert params.channel == "D123456"
-        assert params.text =~ "Your message was removed because it contained personal identifiable information"
+
+        assert params.text =~
+                 "Your message was removed because it contained personal identifiable information"
+
         {:ok, %{"ok" => true}}
     end)
 

--- a/test/pii_detector/platform/slack/bot_test.exs
+++ b/test/pii_detector/platform/slack/bot_test.exs
@@ -2,8 +2,7 @@ defmodule PIIDetector.Platform.Slack.BotTest do
   use ExUnit.Case
   import Mox
   alias PIIDetector.Detector.MockPIIDetector
-  alias PIIDetector.Platform.Slack.Bot
-  alias PIIDetector.Slack.MockAPI
+  alias PIIDetector.Platform.Slack.{Bot, MockAPI}
 
   # Make sure mocks expectations are verified when the test exits
   setup :verify_on_exit!
@@ -13,7 +12,8 @@ defmodule PIIDetector.Platform.Slack.BotTest do
     Application.put_env(:pii_detector, :pii_detector_module, MockPIIDetector)
 
     # Configure the Slack API mock for tests
-    Application.put_env(:pii_detector, :slack_api_module, MockAPI)
+    # Use the new path for the slack_underlying_api config
+    Application.put_env(:pii_detector, :slack_underlying_api, MockAPI)
 
     # Default bot structure for tests
     bot = %{token: "xoxb-test-token", team_id: "T12345", user_id: "U12345"}
@@ -29,7 +29,7 @@ defmodule PIIDetector.Platform.Slack.BotTest do
     on_exit(fn ->
       # Clean up the environment
       Application.delete_env(:pii_detector, :pii_detector_module)
-      Application.delete_env(:pii_detector, :slack_api_module)
+      Application.delete_env(:pii_detector, :slack_underlying_api)
     end)
 
     %{bot: bot, message: message}
@@ -185,7 +185,7 @@ defmodule PIIDetector.Platform.Slack.BotTest do
       "chat.postMessage", token, params ->
         assert token == "xoxb-test-token"
         assert params.channel == "D123456"
-        assert params.text =~ "Your message has been removed"
+        assert params.text =~ "Your message was removed because it contained personal identifiable information"
         {:ok, %{"ok" => true}}
     end)
 

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -8,5 +8,5 @@ defmodule PIIDetector.TestMocks do
   defmock(PIIDetector.Detector.MockPIIDetector, for: PIIDetector.Detector.PIIDetectorBehaviour)
 
   # Mock for the Slack API
-  defmock(PIIDetector.Slack.MockAPI, for: PIIDetector.Slack.APIBehaviour)
+  defmock(PIIDetector.Platform.Slack.MockAPI, for: PIIDetector.Platform.Slack.APIBehaviour)
 end


### PR DESCRIPTION
## Description

Refactor bot, extracts Slack API calls from there to its own module.

## Type of Change

- [x] Refactor
## How Has This Been Tested?

- [x] Unit tests (`mix test`)
- [ ] Integration tests 
- [x] Manual testing

## Checklist

- [x] My code follows the code style and architecture principles of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#10 